### PR TITLE
fix: detect markdonw file change correctly

### DIFF
--- a/AspNetCoreWebApi/Program.cs
+++ b/AspNetCoreWebApi/Program.cs
@@ -18,17 +18,18 @@ var contetRootPath = builder.Environment.ContentRootPath;
 var isDevelopment = builder.Environment.IsDevelopment();
 builder.Services.Configure<DocumentsWatchServiceOptions>(options =>
 {
-    options.InputDir = Path.Combine(contetRootPath, "../AngularStandalone/src/assets/docs");
+    options.InputDir = Path.Combine(contetRootPath, "Docs/md");
+    options.OutputDir = Path.Combine(contetRootPath, "Docs/json");
     if (isDevelopment)
     {
-        options.OutputDir = Path.Combine(contetRootPath, "../AngularStandalone/src/assets/json");
+        options.IndexDir = Path.Combine(contetRootPath, "../AngularStandalone/src/assets");
     }
     else
     {
-        options.OutputDir = Path.Combine(contetRootPath, "../AngularStandalone/dist/assets/json");
+        options.IndexDir = Path.Combine(contetRootPath, "../AngularStandalone/dist/assets");
     }
 });
-builder.Services.AddSingleton<Microsoft.Extensions.Hosting.IHostedService, DocumentsWatchService>();
+builder.Services.AddSingleton<IHostedService, DocumentsWatchService>();
 
 var app = builder.Build();
 

--- a/Net6Markdown2JsonConverter/IMarkdownConverterService.cs
+++ b/Net6Markdown2JsonConverter/IMarkdownConverterService.cs
@@ -3,6 +3,6 @@
 public interface IMarkdownConverterService
 {
     ValueTask RunAsync(CommandLineOptions options);
-    ValueTask ConvertAsync(string? input, string? output, string indexDir, DateTime? dateFrom = null);
+    ValueTask ConvertAsync(string? input, string? output, string? indexDir, DateTime? dateFrom = null);
 }
 


### PR DESCRIPTION
Getting `TaskCompletionSource` by method or local function doesn't work. `IChangeToken` from `Watch()` method never completed.

Moving file watch code to while loop, then it works as expected.